### PR TITLE
Fix date property in transactions

### DIFF
--- a/script.gs
+++ b/script.gs
@@ -182,7 +182,7 @@ function getTransactions() {
 
       for (var i in transactions) {
 
-        transactionsSheet.getRange(row_counter,1).setValue([transactions[i].valueDate]);
+        transactionsSheet.getRange(row_counter,1).setValue([transactions[i].bookingDate]);
 
         if (transactions[i].creditorName) {
             var trx_text = transactions[i].creditorName


### PR DESCRIPTION
I thought this was a great demo but I noticed it wasn't importing the `Date` column in the `Transactions` tab.

This PR changes the date from `valueDate` to `bookingDate` to align with the transactions API https://nordigen.com/en/docs/account-information/output/transactions/.